### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "$ python3 puzzle.py"

--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ Contributors:
 
 - [Tay Yang Shun](http://github.com/yangshun)
 - [Emmanuel Goh](http://github.com/emman27)
+[![Run on Repl.it](https://repl.it/badge/github/yangshun/2048-python)](https://repl.it/github/yangshun/2048-python)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@ed3yuu/2048-python).